### PR TITLE
Add a service to run the remote repl in the background

### DIFF
--- a/cljrepl.service
+++ b/cljrepl.service
@@ -2,9 +2,9 @@
 Description=Remote clojure REPL
 
 [Service]
-ExecStart=/home/vagrant/bin/lein trampoline repl :headless :host 0.0.0.0 :port 7888
+ExecStart=/home/vagrant/bin/lein repl :headless :host 0.0.0.0 :port 7888
 User=vagrant
-WorkingDirectory=/vagrant
+WorkingDirectory=/lemmings
 
 [Install]
 WantedBy=multi-user.target

--- a/cljrepl.service
+++ b/cljrepl.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Remote clojure REPL
+
+[Service]
+ExecStart=/home/vagrant/bin/lein trampoline repl :headless :host 0.0.0.0 :port 7888
+User=vagrant
+WorkingDirectory=/vagrant
+
+[Install]
+WantedBy=multi-user.target

--- a/cljrepl.service
+++ b/cljrepl.service
@@ -8,3 +8,4 @@ WorkingDirectory=/lemmings
 
 [Install]
 WantedBy=multi-user.target
+WantedBy=lemmings.mount

--- a/provision.sh
+++ b/provision.sh
@@ -6,6 +6,7 @@ set -o errexit
 readonly Progname=$(basename "$0")
 readonly Progdir=$(readlink -m $(dirname "$0"))
 readonly Args="$@"
+readonly BasePath="/vagrant"
 
 clojure () {
     echo "Installing clojure"
@@ -14,6 +15,10 @@ clojure () {
     wget -q -O /home/vagrant/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
     chmod a+x /home/vagrant/bin/lein
     chown vagrant:vagrant /home/vagrant/bin/lein
+
+    cp -f ${BasePath}/cljrepl.service /etc/systemd/system/
+    systemctl enable cljrepl.service
+    systemctl start cljrepl.service
 }
 
 main () {

--- a/provision.sh
+++ b/provision.sh
@@ -3,10 +3,7 @@
 set -o nounset
 set -o errexit
 
-readonly Progname=$(basename "$0")
-readonly Progdir=$(readlink -m $(dirname "$0"))
-readonly Args="$@"
-readonly BasePath="/vagrant"
+readonly BasePath="/lemmings"
 
 clojure () {
     echo "Installing clojure"
@@ -27,23 +24,23 @@ main () {
     export DEBIAN_FRONTEND=noninteractive
 
     # Update apt cache
-    apt-get update &> /dev/null
-    apt-get autoclean &> /dev/null
-    apt-get autoremove -y &> /dev/null
+    apt-get update
+    apt-get autoclean
+    apt-get autoremove -y
 
     # Install some base software
-    apt-get install -y curl vim &> /dev/null
+    apt-get install -y curl vim
 
     # Create bin dir for user vagrant
     mkdir -p /home/vagrant/bin
     chown vagrant:vagrant /home/vagrant/bin
 
     # Navigate to project directory on login
-    echo "cd /lemmings" >> /home/vagrant/.bashrc
+    echo "cd ${BasePath}" >> /home/vagrant/.bashrc
 
     # Add greeting
     echo "Hello 💧 Lemming :)" > /etc/motd
 
     clojure
 }
-main $Args
+main


### PR DESCRIPTION
As discussed in #2, this PR adds a "cljrepl.service" for systemd, starting a remote repl on port 7888 which can be used to connect to from an editor or a shell running on the host system.

It's implemented as a "normal" systemd service, so it can be interacted with using systectl to restart, stop or start it. It's also possible to disable it that way but keep in mind that running the provisioning again it will enable it.